### PR TITLE
using uri_escape_utf8 because Net::OAuth uses uri_escape_utf8

### DIFF
--- a/lib/AnyEvent/Twitter/Stream.pm
+++ b/lib/AnyEvent/Twitter/Stream.pm
@@ -79,7 +79,7 @@ sub new {
     my $request_body;
     if ($method eq 'filter' || $method eq 'userstream') {
         $request_method = 'POST';
-        $request_body = join '&', map "$_=" . URI::Escape::uri_escape($post_args{$_}), keys %post_args;
+        $request_body = join '&', map "$_=" . URI::Escape::uri_escape_utf8($post_args{$_}), keys %post_args;
     }
 
     my $auth;


### PR DESCRIPTION
今は特に必要は無いんですが、Net::OAuth が uri_escape_utf8 を使っていて
AnyEvent::Twitter::Stream が uri_escape を使ってると、将来的に %post_args に日本語とか
入れるようになると困った事になると思うので、パッチ書いときました。
